### PR TITLE
 support higher zoom levels

### DIFF
--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -198,8 +198,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     unsigned int  sqlite3_ret;
     unsigned char *tile_content;
     unsigned int  tile_read_bytes;
-    short         tile_zoom, tile_row, tile_column;
-    unsigned int  tms_tile_row;
+    unsigned int  tile_zoom, tile_row, tile_column, tms_tile_row;
 
     ngx_http_mbtiles_loc_conf_t *mbtiles_config;
     mbtiles_config = ngx_http_get_module_loc_conf(r, ngx_http_mbtiles_module);

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -198,7 +198,8 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     unsigned int  sqlite3_ret;
     unsigned char *tile_content;
     unsigned int  tile_read_bytes;
-    short         tile_zoom, tile_row, tile_column, tms_tile_row;
+    short         tile_zoom, tile_row, tile_column;
+    unsigned int  tms_tile_row;
 
     ngx_http_mbtiles_loc_conf_t *mbtiles_config;
     mbtiles_config = ngx_http_get_module_loc_conf(r, ngx_http_mbtiles_module);


### PR DESCRIPTION
The current version is limited to zoom level 15 because the relevant data types that reference `tile_column` and `tile_row` are typed as `short` (i.e. max 2^15).

This is fixed by changing the types to `int`.